### PR TITLE
SLUserAttributeにint引数サポートを追加

### DIFF
--- a/Sources/SwiftSlang/SLComponentType.mm
+++ b/Sources/SwiftSlang/SLComponentType.mm
@@ -26,13 +26,20 @@ static NSArray<SLUserAttribute*>* collectUserAttributes(slang::VariableReflectio
 
         uint32_t argCount = attr->getArgumentCount();
         NSMutableArray<NSNumber*>* floatArgs = [NSMutableArray arrayWithCapacity:argCount];
+        NSMutableArray<NSNumber*>* intArgs = [NSMutableArray arrayWithCapacity:argCount];
         NSMutableArray<NSString*>* stringArgs = [NSMutableArray arrayWithCapacity:argCount];
 
         for (uint32_t j = 0; j < argCount; j++) {
             // Try to get float value
             float floatValue = 0.0f;
+            int intValue = 0;
             if (SLANG_SUCCEEDED(attr->getArgumentValueFloat(j, &floatValue))) {
                 [floatArgs addObject:@(floatValue)];
+                [intArgs addObject:@(0)];
+                [stringArgs addObject:@""];
+            } else if (SLANG_SUCCEEDED(attr->getArgumentValueInt(j, &intValue))) {
+                [floatArgs addObject:@(0.0f)];
+                [intArgs addObject:@(intValue)];
                 [stringArgs addObject:@""];
             } else {
                 // Try to get string value
@@ -40,9 +47,11 @@ static NSArray<SLUserAttribute*>* collectUserAttributes(slang::VariableReflectio
                 const char* strValue = attr->getArgumentValueString(j, &strLen);
                 if (strValue && strLen > 0) {
                     [floatArgs addObject:@(0.0f)];
+                    [intArgs addObject:@(0)];
                     [stringArgs addObject:[NSString stringWithUTF8String:strValue]];
                 } else {
                     [floatArgs addObject:@(0.0f)];
+                    [intArgs addObject:@(0)];
                     [stringArgs addObject:@""];
                 }
             }
@@ -50,6 +59,7 @@ static NSArray<SLUserAttribute*>* collectUserAttributes(slang::VariableReflectio
 
         SLUserAttribute* userAttr = [[SLUserAttribute alloc] initWithName:attrName
                                                             floatArguments:floatArgs
+                                                              intArguments:intArgs
                                                            stringArguments:stringArgs];
         [attributes addObject:userAttr];
     }

--- a/Sources/SwiftSlang/SLUserAttribute.h
+++ b/Sources/SwiftSlang/SLUserAttribute.h
@@ -13,16 +13,22 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSUInteger argumentCount;
 
 /// Float argument values (indexed by argument position).
-/// Returns nil for non-float arguments.
+/// Returns 0 for non-float arguments.
 @property (nonatomic, readonly) NSArray<NSNumber *> *floatArguments;
 
+/// Int argument values (indexed by argument position).
+/// Bool values (true/false) are represented as 1/0.
+/// Returns 0 for non-int arguments.
+@property (nonatomic, readonly) NSArray<NSNumber *> *intArguments;
+
 /// String argument values (indexed by argument position).
-/// Returns nil for non-string arguments.
+/// Returns empty string for non-string arguments.
 @property (nonatomic, readonly) NSArray<NSString *> *stringArguments;
 
 - (instancetype)initWithName:(NSString *)name
-               floatArguments:(NSArray<NSNumber *> *)floatArguments
-              stringArguments:(NSArray<NSString *> *)stringArguments;
+              floatArguments:(NSArray<NSNumber *> *)floatArguments
+                intArguments:(NSArray<NSNumber *> *)intArguments
+             stringArguments:(NSArray<NSString *> *)stringArguments;
 
 @end
 

--- a/Sources/SwiftSlang/SLUserAttribute.mm
+++ b/Sources/SwiftSlang/SLUserAttribute.mm
@@ -3,14 +3,16 @@
 @implementation SLUserAttribute
 
 - (instancetype)initWithName:(NSString *)name
-               floatArguments:(NSArray<NSNumber *> *)floatArguments
-              stringArguments:(NSArray<NSString *> *)stringArguments {
+              floatArguments:(NSArray<NSNumber *> *)floatArguments
+                intArguments:(NSArray<NSNumber *> *)intArguments
+             stringArguments:(NSArray<NSString *> *)stringArguments {
     self = [super init];
     if (self) {
         _name = [name copy];
         _floatArguments = [floatArguments copy];
+        _intArguments = [intArguments copy];
         _stringArguments = [stringArguments copy];
-        _argumentCount = MAX(floatArguments.count, stringArguments.count);
+        _argumentCount = MAX(MAX(floatArguments.count, intArguments.count), stringArguments.count);
     }
     return self;
 }


### PR DESCRIPTION
## Summary
- `SLUserAttribute` に `intArguments` プロパティを追加
- `collectUserAttributes` で `getArgumentValueInt` を試行するロジックを追加（float → int → string の順）
- `[toggle(true)]` などの bool/int 引数を持つ attribute が取得可能に

## Test plan
- [ ] Slang シェーダーで `[toggle(true)]` attribute を付けた uniform を定義して動作確認
- [ ] `intArguments[0]` が `1` (true) であることを確認
- [ ] 既存の float/string attribute が引き続き正しく取得されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)