### PR TITLE
Add UAV parameter category and entry point reflection

### DIFF
--- a/Sources/SwiftSlang/SLComponentType.mm
+++ b/Sources/SwiftSlang/SLComponentType.mm
@@ -111,6 +111,15 @@ static void collectParameterForCategory(
             [outParameters addObject:param];
             break;
         }
+        case slang::ParameterCategory::UnorderedAccess: {
+            size_t offset = varLayout->getOffset(SLANG_PARAMETER_CATEGORY_UNORDERED_ACCESS);
+            SLShaderParameter* param = [[SLShaderParameter alloc] initWithName:name
+                                                                      category:SLParameterCategoryUnorderedAccess
+                                                                  bindingIndex:(NSUInteger)offset
+                                                                userAttributes:userAttributes];
+            [outParameters addObject:param];
+            break;
+        }
         case slang::ParameterCategory::Mixed: {
             unsigned int catCount = varLayout->getCategoryCount();
             for (unsigned int i = 0; i < catCount; i++) {

--- a/Sources/SwiftSlang/SLEntryPoint.h
+++ b/Sources/SwiftSlang/SLEntryPoint.h
@@ -4,6 +4,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class SLBlob;
+@class SLUserAttribute;
 
 /// Stage type for shader entry points.
 /// These values correspond to SlangStage in slang.h.
@@ -35,6 +36,13 @@ typedef NS_ENUM(int32_t, SLShaderStage) {
 
 /// Get the stage of this entry point.
 @property (nonatomic, readonly) SLShaderStage stage;
+
+/// User-defined attributes on this entry point (e.g., [dispatch(1, 1, 1)]).
+@property (nonatomic, readonly) NSArray<SLUserAttribute *> *userAttributes;
+
+/// Compute thread group size from [numthreads(X, Y, Z)].
+/// Returns {0, 0, 0} for non-compute entry points.
+@property (nonatomic, readonly) NSArray<NSNumber *> *computeThreadGroupSize;
 
 @end
 

--- a/Sources/SwiftSlang/SLEntryPoint.mm
+++ b/Sources/SwiftSlang/SLEntryPoint.mm
@@ -3,6 +3,7 @@
 #include "../Slang/include/slang-com-ptr.h"
 
 #import "SLEntryPoint.h"
+#import "SLUserAttribute.h"
 
 @interface SLEntryPoint () {
     Slang::ComPtr<slang::IEntryPoint> _entryPoint;
@@ -51,6 +52,87 @@
         }
     }
     return SLShaderStageNone;
+}
+
+- (NSArray<SLUserAttribute *> *)userAttributes {
+    if (!_entryPoint) return @[];
+
+    slang::IComponentType *componentType = static_cast<slang::IComponentType *>(_entryPoint.get());
+    slang::ProgramLayout *layout = componentType->getLayout();
+    if (!layout || layout->getEntryPointCount() == 0) return @[];
+
+    slang::EntryPointReflection *reflection = layout->getEntryPointByIndex(0);
+    if (!reflection) return @[];
+
+    slang::FunctionReflection *func = reflection->getFunction();
+    if (!func) return @[];
+
+    unsigned int attrCount = func->getUserAttributeCount();
+    if (attrCount == 0) return @[];
+
+    NSMutableArray<SLUserAttribute *> *attributes = [NSMutableArray arrayWithCapacity:attrCount];
+    for (unsigned int i = 0; i < attrCount; i++) {
+        slang::Attribute *attr = func->getUserAttributeByIndex(i);
+        if (!attr) continue;
+
+        const char *attrNameStr = attr->getName();
+        if (!attrNameStr) continue;
+        NSString *attrName = [NSString stringWithUTF8String:attrNameStr];
+
+        uint32_t argCount = attr->getArgumentCount();
+        NSMutableArray<NSNumber *> *floatArgs = [NSMutableArray arrayWithCapacity:argCount];
+        NSMutableArray<NSNumber *> *intArgs = [NSMutableArray arrayWithCapacity:argCount];
+        NSMutableArray<NSString *> *stringArgs = [NSMutableArray arrayWithCapacity:argCount];
+
+        for (uint32_t j = 0; j < argCount; j++) {
+            float floatValue = 0.0f;
+            int intValue = 0;
+            if (SLANG_SUCCEEDED(attr->getArgumentValueFloat(j, &floatValue))) {
+                [floatArgs addObject:@(floatValue)];
+                [intArgs addObject:@(0)];
+                [stringArgs addObject:@""];
+            } else if (SLANG_SUCCEEDED(attr->getArgumentValueInt(j, &intValue))) {
+                [floatArgs addObject:@(0.0f)];
+                [intArgs addObject:@(intValue)];
+                [stringArgs addObject:@""];
+            } else {
+                size_t strLen = 0;
+                const char *strValue = attr->getArgumentValueString(j, &strLen);
+                if (strValue && strLen > 0) {
+                    [floatArgs addObject:@(0.0f)];
+                    [intArgs addObject:@(0)];
+                    [stringArgs addObject:[NSString stringWithUTF8String:strValue]];
+                } else {
+                    [floatArgs addObject:@(0.0f)];
+                    [intArgs addObject:@(0)];
+                    [stringArgs addObject:@""];
+                }
+            }
+        }
+
+        SLUserAttribute *userAttr = [[SLUserAttribute alloc] initWithName:attrName
+                                                            floatArguments:floatArgs
+                                                              intArguments:intArgs
+                                                           stringArguments:stringArgs];
+        [attributes addObject:userAttr];
+    }
+
+    return [attributes copy];
+}
+
+- (NSArray<NSNumber *> *)computeThreadGroupSize {
+    if (!_entryPoint) return @[@0, @0, @0];
+
+    slang::IComponentType *componentType = static_cast<slang::IComponentType *>(_entryPoint.get());
+    slang::ProgramLayout *layout = componentType->getLayout();
+    if (!layout || layout->getEntryPointCount() == 0) return @[@0, @0, @0];
+
+    slang::EntryPointReflection *reflection = layout->getEntryPointByIndex(0);
+    if (!reflection) return @[@0, @0, @0];
+
+    SlangUInt sizes[3] = {0, 0, 0};
+    reflection->getComputeThreadGroupSize(3, sizes);
+    return @[@(sizes[0]), @(sizes[1]), @(sizes[2])];
 }
 
 - (slang::IComponentType *)asComponentType {

--- a/Sources/SwiftSlang/SLShaderParameter.h
+++ b/Sources/SwiftSlang/SLShaderParameter.h
@@ -12,6 +12,7 @@ typedef NS_ENUM(NSInteger, SLParameterCategory) {
     SLParameterCategoryShaderResource,
     SLParameterCategorySamplerState,
     SLParameterCategoryUniform,
+    SLParameterCategoryUnorderedAccess,
 };
 
 /// Represents a shader parameter extracted from Slang reflection.


### PR DESCRIPTION
## Summary
- `SLParameterCategory` に `UnorderedAccess` を追加し、UAV バインディングに対応
- `SLEntryPoint` に `userAttributes` プロパティを追加し、エントリーポイント関数のユーザー定義属性を取得可能に
- `SLEntryPoint` に `computeThreadGroupSize` プロパティを追加し、`[numthreads(X, Y, Z)]` のリフレクションに対応

## Test plan
- [ ] Compute shader で `numthreads` 属性が正しく取得できることを確認
- [ ] UAV パラメータのバインディングインデックスが正しいことを確認
- [ ] ユーザー定義属性の float/int/string 引数が正しくパースされることを確認