### PR TITLE
Add entry point attributes, UAV support, and type layout

### DIFF
--- a/Sources/SwiftSlang/SLComponentType.mm
+++ b/Sources/SwiftSlang/SLComponentType.mm
@@ -4,6 +4,7 @@
 
 #import "SLComponentType.h"
 #import "SLShaderParameter.h"
+#import "SLTypeLayout.h"
 #import "SLUserAttribute.h"
 #import "SLError.h"
 
@@ -67,6 +68,10 @@ static NSArray<SLUserAttribute*>* collectUserAttributes(slang::VariableReflectio
     return [attributes copy];
 }
 
+@interface SLTypeLayout ()
+- (instancetype)initWithTypeLayoutPtr:(slang::TypeLayoutReflection*)typeLayoutPtr;
+@end
+
 static void collectParameterForCategory(
     slang::VariableLayoutReflection* varLayout,
     slang::ParameterCategory category,
@@ -74,13 +79,18 @@ static void collectParameterForCategory(
     NSArray<SLUserAttribute*>* userAttributes,
     NSMutableArray<SLShaderParameter*>* outParameters
 ) {
+    slang::TypeLayoutReflection* rawTypeLayout = varLayout->getTypeLayout();
+    SLTypeLayout* typeLayout = rawTypeLayout
+        ? [[SLTypeLayout alloc] initWithTypeLayoutPtr:rawTypeLayout]
+        : nil;
     switch (category) {
         case slang::ParameterCategory::ShaderResource: {
             size_t offset = varLayout->getOffset(SLANG_PARAMETER_CATEGORY_SHADER_RESOURCE);
             SLShaderParameter* param = [[SLShaderParameter alloc] initWithName:name
                                                                       category:SLParameterCategoryShaderResource
                                                                   bindingIndex:(NSUInteger)offset
-                                                                userAttributes:userAttributes];
+                                                                userAttributes:userAttributes
+                                                                    typeLayout:typeLayout];
             [outParameters addObject:param];
             break;
         }
@@ -89,7 +99,8 @@ static void collectParameterForCategory(
             SLShaderParameter* param = [[SLShaderParameter alloc] initWithName:name
                                                                       category:SLParameterCategorySamplerState
                                                                   bindingIndex:(NSUInteger)offset
-                                                                userAttributes:userAttributes];
+                                                                userAttributes:userAttributes
+                                                                    typeLayout:typeLayout];
             [outParameters addObject:param];
             break;
         }
@@ -98,7 +109,8 @@ static void collectParameterForCategory(
             SLShaderParameter* param = [[SLShaderParameter alloc] initWithName:name
                                                                       category:SLParameterCategoryConstantBuffer
                                                                   bindingIndex:(NSUInteger)offset
-                                                                userAttributes:userAttributes];
+                                                                userAttributes:userAttributes
+                                                                    typeLayout:typeLayout];
             [outParameters addObject:param];
             break;
         }
@@ -107,7 +119,8 @@ static void collectParameterForCategory(
             SLShaderParameter* param = [[SLShaderParameter alloc] initWithName:name
                                                                       category:SLParameterCategoryUniform
                                                                   bindingIndex:(NSUInteger)offset
-                                                                userAttributes:userAttributes];
+                                                                userAttributes:userAttributes
+                                                                    typeLayout:typeLayout];
             [outParameters addObject:param];
             break;
         }
@@ -116,7 +129,8 @@ static void collectParameterForCategory(
             SLShaderParameter* param = [[SLShaderParameter alloc] initWithName:name
                                                                       category:SLParameterCategoryUnorderedAccess
                                                                   bindingIndex:(NSUInteger)offset
-                                                                userAttributes:userAttributes];
+                                                                userAttributes:userAttributes
+                                                                    typeLayout:typeLayout];
             [outParameters addObject:param];
             break;
         }

--- a/Sources/SwiftSlang/SLShaderParameter.h
+++ b/Sources/SwiftSlang/SLShaderParameter.h
@@ -3,6 +3,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class SLUserAttribute;
+@class SLTypeLayout;
 
 /// Parameter category for shader resources.
 /// These values correspond to SlangParameterCategory in slang.h.
@@ -30,10 +31,15 @@ typedef NS_ENUM(NSInteger, SLParameterCategory) {
 /// User-defined attributes on this parameter (e.g., [range(0.0, 1.0, "desc")]).
 @property (nonatomic, readonly) NSArray<SLUserAttribute *> *userAttributes;
 
+/// Type layout information for this parameter.
+/// Returns nil if the type layout is not available.
+@property (nonatomic, readonly, nullable) SLTypeLayout *typeLayout;
+
 - (instancetype)initWithName:(NSString *)name
                     category:(SLParameterCategory)category
                 bindingIndex:(NSUInteger)bindingIndex
-              userAttributes:(NSArray<SLUserAttribute *> *)userAttributes;
+              userAttributes:(NSArray<SLUserAttribute *> *)userAttributes
+                  typeLayout:(nullable SLTypeLayout *)typeLayout;
 
 @end
 

--- a/Sources/SwiftSlang/SLShaderParameter.mm
+++ b/Sources/SwiftSlang/SLShaderParameter.mm
@@ -1,18 +1,21 @@
 #import "SLShaderParameter.h"
 #import "SLUserAttribute.h"
+#import "SLTypeLayout.h"
 
 @implementation SLShaderParameter
 
 - (instancetype)initWithName:(NSString *)name
                     category:(SLParameterCategory)category
                 bindingIndex:(NSUInteger)bindingIndex
-              userAttributes:(NSArray<SLUserAttribute *> *)userAttributes {
+              userAttributes:(NSArray<SLUserAttribute *> *)userAttributes
+                  typeLayout:(SLTypeLayout *)typeLayout {
     self = [super init];
     if (self) {
         _name = [name copy];
         _category = category;
         _bindingIndex = bindingIndex;
         _userAttributes = [userAttributes copy];
+        _typeLayout = typeLayout;
     }
     return self;
 }

--- a/Sources/SwiftSlang/SLTypeLayout.h
+++ b/Sources/SwiftSlang/SLTypeLayout.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A wrapper for slang::TypeLayoutReflection
+/// Provides type layout information such as size and element type layout.
+@interface SLTypeLayout : NSObject
+
+/// The byte size of this type (using Uniform parameter category).
+@property (nonatomic, readonly) NSUInteger size;
+
+/// The element type layout for buffer/array types (e.g., the T in RWStructuredBuffer<T>).
+/// Returns nil if not applicable.
+@property (nonatomic, readonly, nullable) SLTypeLayout *elementTypeLayout;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/SwiftSlang/SLTypeLayout.mm
+++ b/Sources/SwiftSlang/SLTypeLayout.mm
@@ -1,0 +1,32 @@
+#include "../Slang/include/slang.h"
+
+#import "SLTypeLayout.h"
+
+@interface SLTypeLayout () {
+    slang::TypeLayoutReflection* _typeLayout;
+}
+@end
+
+@implementation SLTypeLayout
+
+- (instancetype)initWithTypeLayoutPtr:(slang::TypeLayoutReflection*)typeLayoutPtr {
+    self = [super init];
+    if (self) {
+        _typeLayout = typeLayoutPtr;
+    }
+    return self;
+}
+
+- (NSUInteger)size {
+    if (!_typeLayout) return 0;
+    return (NSUInteger)_typeLayout->getSize(SLANG_PARAMETER_CATEGORY_UNIFORM);
+}
+
+- (nullable SLTypeLayout *)elementTypeLayout {
+    if (!_typeLayout) return nil;
+    slang::TypeLayoutReflection* elementLayout = _typeLayout->getElementTypeLayout();
+    if (!elementLayout) return nil;
+    return [[SLTypeLayout alloc] initWithTypeLayoutPtr:elementLayout];
+}
+
+@end

--- a/Sources/SwiftSlang/module.modulemap
+++ b/Sources/SwiftSlang/module.modulemap
@@ -7,6 +7,7 @@ module SwiftSlang {
     header "SLModule.h"
     header "SLEntryPoint.h"
     header "SLUserAttribute.h"
+    header "SLTypeLayout.h"
     header "SLShaderParameter.h"
     header "SLComponentType.h"
 


### PR DESCRIPTION
## Summary
- Add `SLParameterCategoryUnorderedAccess` for UAV resource binding reflection
- Add `userAttributes` and `computeThreadGroupSize` properties to `SLEntryPoint`
- Add `SLTypeLayout` class to expose type layout information (size, element type layout) on `SLShaderParameter`

## Test plan
- [ ] Build the project and verify no compilation errors
- [ ] Verify UAV parameters are correctly reflected with binding indices
- [ ] Verify entry point user attributes and compute thread group sizes are retrieved correctly
- [ ] Verify `SLTypeLayout.size` and `elementTypeLayout` return expected values for buffer types

🤖 Generated with [Claude Code](https://claude.com/claude-code)