### PR TITLE
Add release workflow and Claude skills

### DIFF
--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: create-release
+description: SwiftSlang の新しいバージョンをリリースする。GitHub Actions の workflow_dispatch をトリガーする。
+argument-hint: [version]
+---
+
+# SwiftSlang リリース作成
+
+バージョン: $ARGUMENTS
+
+## 手順
+
+1. **バージョン確認**: `$ARGUMENTS` がセマンティックバージョニング (X.Y.Z) に従っているか確認する
+
+2. **リリース内容の確認**: 前回リリースからの変更を確認する
+   - `git log $(git describe --tags --abbrev=0)..HEAD --oneline` で差分コミットを確認
+   - 変更内容をユーザーに提示して確認を取る
+
+3. **未コミットの変更確認**: `git status` でコミット漏れがないか確認する。未コミットの変更がある場合はユーザーに警告する
+
+4. **mainにpush済みか確認**: `git log origin/main..HEAD --oneline` でpush されていないコミットがないか確認する。あればユーザーに警告する
+
+5. **GitHub Actions トリガー**: 以下のコマンドでリリースワークフローを実行する
+   ```
+   gh workflow run release.yml -f version=$ARGUMENTS
+   ```
+
+6. **ワークフローの監視**: 実行状況を確認する
+   ```
+   gh run list --workflow=release.yml --limit=1
+   ```
+
+7. **結果の報告**: リリースURLをユーザーに報告する
+
+## 注意事項
+
+- Slang バイナリの更新が必要な場合は、先に `/update-slang` を実行すること
+- mainブランチから実行すること
+- コミットメッセージ・リリースノートにキャラ口調を使わないこと

--- a/.claude/skills/update-slang/SKILL.md
+++ b/.claude/skills/update-slang/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: update-slang
+description: Slang のバージョンを更新し、XCFramework をビルドしてバイナリリリースを作成する。ローカルでのビルドが必要。
+argument-hint: [slang-version]
+---
+
+# Slang 更新
+
+更新先バージョン: $ARGUMENTS (例: v2025.22)
+
+## 前提条件の確認
+
+以下のツールがインストールされているか確認する:
+- cmake (3.26以上)
+- ninja (1.11以上)
+- Xcode Command Line Tools
+
+```
+cmake --version && ninja --version && xcodebuild -version
+```
+
+## 手順
+
+### 1. サブモジュール更新
+
+```bash
+git submodule update --init --recursive
+cd slang
+git fetch --tags
+git checkout $ARGUMENTS
+cd ..
+```
+
+### 2. ヘッダーファイルの更新
+
+slang サブモジュールから最新ヘッダーを `Sources/Slang/include/` にコピーする:
+
+```bash
+cp slang/include/slang.h Sources/Slang/include/
+cp slang/include/slang-com-ptr.h Sources/Slang/include/
+cp slang/include/slang-com-helper.h Sources/Slang/include/
+```
+
+ヘッダーに差分があるか `git diff` で確認し、API の破壊的変更がないかユーザーに報告する。
+
+### 3. XCFramework ビルド
+
+```bash
+make clean
+make all
+```
+
+ビルドには 10〜30 分かかる。ビルド完了後、成果物を確認:
+
+```bash
+make verify
+cat xcframework/SlangBinary.xcframework.zip.checksum
+```
+
+### 4. バイナリリリース作成
+
+Slang バイナリ専用のリリースを作成する。タグ形式は `slang-binary/$ARGUMENTS`:
+
+```bash
+gh release create "slang-binary/$ARGUMENTS" \
+  xcframework/SlangBinary.xcframework.zip \
+  --title "Slang Binary $ARGUMENTS" \
+  --notes "Slang $ARGUMENTS のプリビルド XCFramework (iOS Device + Simulator)"
+```
+
+### 5. Package.swift 更新
+
+`Package.swift` の `binaryTarget` を更新する:
+- `url`: 新しいリリースの URL に変更
+- `checksum`: 新しい checksum に変更
+
+```swift
+.binaryTarget(
+    name: "SlangBinary",
+    url: "https://github.com/shivaduke28/swift-slang/releases/download/slang-binary/$ARGUMENTS/SlangBinary.xcframework.zip",
+    checksum: "<checksumファイルの値>"
+),
+```
+
+### 6. README.md 更新
+
+README.md の Slang バージョン表記を更新する。
+
+### 7. コミット
+
+変更をコミットする（コミットメッセージにキャラ口調を使わないこと）:
+
+```
+Update Slang to $ARGUMENTS
+```
+
+## 注意事項
+
+- ビルドは Apple Silicon Mac で実行すること
+- mainブランチで作業すること
+- ビルド成果物 (build/, xcframework/) は .gitignore されている
+- コミット後、`/create-release` でパッケージリリースを作成できる

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version without v prefix (e.g. 0.4.0)'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate version format
+        run: |
+          if ! echo "${{ inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: Version must be in X.Y.Z format"
+            exit 1
+          fi
+
+      - name: Remove submodule references
+        run: |
+          if [ -f .gitmodules ]; then
+            git rm .gitmodules
+          fi
+          if [ -d slang ]; then
+            git rm -rf --cached slang 2>/dev/null || true
+            rm -rf slang
+          fi
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create release commit and tag
+        run: |
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No submodule to remove, tagging current state"
+          else
+            git commit -m "Release v${{ inputs.version }}"
+          fi
+          git tag "v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ inputs.version }}" \
+            --title "v${{ inputs.version }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for creating releases (`workflow_dispatch`)
  - Removes submodule references before tagging so SPM users don't pull the heavy slang submodule
- Add Claude skill `/create-release` to trigger release workflow
- Add Claude skill `/update-slang` to guide Slang version updates

## Context
Closes https://github.com/shivaduke28/swift-slang/issues/6

Release strategy:
- `main` branch has the slang submodule for development
- Release tags are created by CI with submodule references removed
- Slang binary releases use `slang-binary/vYYYY.XX` tag format, separate from package version tags

## Test plan
- [ ] Verify `/create-release` skill is visible in Claude Code
- [ ] Verify `/update-slang` skill is visible in Claude Code
- [ ] Test release workflow with a dry run (e.g. `v0.4.0-rc1`)