### PR TITLE
Update slang-deprecated.h to v2026.4.2

### DIFF
--- a/Sources/Slang/include/slang-deprecated.h
+++ b/Sources/Slang/include/slang-deprecated.h
@@ -522,9 +522,22 @@ extern "C"
 
     SLANG_API SlangReflectionType* spReflectionTypeLayout_GetType(SlangReflectionTypeLayout* type);
     SLANG_API SlangTypeKind spReflectionTypeLayout_getKind(SlangReflectionTypeLayout* type);
+    /** Get the size of a type layout in the specified parameter category.
+     *
+     * Returns `SLANG_UNBOUNDED_SIZE` for unbounded resources (e.g., unsized arrays).
+     * Returns `SLANG_UNKNOWN_SIZE` when the size depends on unresolved generic parameters or
+     * link-time constants.
+     */
     SLANG_API size_t spReflectionTypeLayout_GetSize(
         SlangReflectionTypeLayout* type,
         SlangParameterCategory category);
+
+    /** Get the stride of a type layout in the specified parameter category.
+     *
+     * Returns `SLANG_UNBOUNDED_SIZE` for unbounded resources.
+     * Returns `SLANG_UNKNOWN_SIZE` when stride depends on unresolved generic parameters or
+     * link-time constants.
+     */
     SLANG_API size_t spReflectionTypeLayout_GetStride(
         SlangReflectionTypeLayout* type,
         SlangParameterCategory category);
@@ -545,6 +558,12 @@ extern "C"
     SLANG_API SlangReflectionVariableLayout* spReflectionTypeLayout_GetExplicitCounter(
         SlangReflectionTypeLayout* typeLayout);
 
+    /** Get the stride between elements of an array type layout.
+     *
+     * Returns `SLANG_UNBOUNDED_SIZE` for unbounded resources.
+     * Returns `SLANG_UNKNOWN_SIZE` when element stride depends on unresolved generic parameters or
+     * link-time constants.
+     */
     SLANG_API size_t spReflectionTypeLayout_GetElementStride(
         SlangReflectionTypeLayout* type,
         SlangParameterCategory category);
@@ -585,6 +604,12 @@ extern "C"
     SLANG_API SlangInt spReflectionTypeLayout_isBindingRangeSpecializable(
         SlangReflectionTypeLayout* typeLayout,
         SlangInt index);
+    /** Get the binding count for a binding range at the specified index.
+     *
+     * Returns `SLANG_UNBOUNDED_SIZE` for unbounded resources.
+     * Returns `SLANG_UNKNOWN_SIZE` when the count depends on unresolved generic parameters or
+     * link-time constants.
+     */
     SLANG_API SlangInt spReflectionTypeLayout_getBindingRangeBindingCount(
         SlangReflectionTypeLayout* typeLayout,
         SlangInt index);
@@ -621,10 +646,22 @@ extern "C"
     SLANG_API SlangInt spReflectionTypeLayout_getDescriptorSetDescriptorRangeCount(
         SlangReflectionTypeLayout* typeLayout,
         SlangInt setIndex);
+    /** Get the index offset for a descriptor range within a descriptor set.
+     *
+     * Returns `SLANG_UNKNOWN_SIZE` when the offset depends on unresolved generic parameters or
+     * link-time constants.
+     */
     SLANG_API SlangInt spReflectionTypeLayout_getDescriptorSetDescriptorRangeIndexOffset(
         SlangReflectionTypeLayout* typeLayout,
         SlangInt setIndex,
         SlangInt rangeIndex);
+
+    /** Get the descriptor count for a descriptor range within a descriptor set.
+     *
+     * Returns `SLANG_UNBOUNDED_SIZE` for unbounded resources.
+     * Returns `SLANG_UNKNOWN_SIZE` when the count depends on unresolved generic parameters or
+     * link-time constants.
+     */
     SLANG_API SlangInt spReflectionTypeLayout_getDescriptorSetDescriptorRangeDescriptorCount(
         SlangReflectionTypeLayout* typeLayout,
         SlangInt setIndex,
@@ -643,6 +680,11 @@ extern "C"
     SLANG_API SlangInt spReflectionTypeLayout_getSubObjectRangeBindingRangeIndex(
         SlangReflectionTypeLayout* typeLayout,
         SlangInt subObjectRangeIndex);
+    /** Get the space offset for a sub-object range.
+     *
+     * Returns `SLANG_UNKNOWN_SIZE` when the offset depends on unresolved generic parameters or
+     * link-time constants.
+     */
     SLANG_API SlangInt spReflectionTypeLayout_getSubObjectRangeSpaceOffset(
         SlangReflectionTypeLayout* typeLayout,
         SlangInt subObjectRangeIndex);
@@ -681,6 +723,8 @@ extern "C"
     SLANG_API bool spReflectionVariable_HasDefaultValue(SlangReflectionVariable* inVar);
     SLANG_API SlangResult
     spReflectionVariable_GetDefaultValueInt(SlangReflectionVariable* inVar, int64_t* rs);
+    SLANG_API SlangResult
+    spReflectionVariable_GetDefaultValueFloat(SlangReflectionVariable* inVar, float* rs);
     SLANG_API SlangReflectionGeneric* spReflectionVariable_GetGenericContainer(
         SlangReflectionVariable* var);
     SLANG_API SlangReflectionVariable* spReflectionVariable_applySpecializations(
@@ -695,9 +739,20 @@ extern "C"
     SLANG_API SlangReflectionTypeLayout* spReflectionVariableLayout_GetTypeLayout(
         SlangReflectionVariableLayout* var);
 
+    /** Get the offset of a variable in the specified parameter category.
+     *
+     * Returns `SLANG_UNKNOWN_SIZE` when the offset depends on unresolved generic parameters or
+     * link-time constants.
+     */
     SLANG_API size_t spReflectionVariableLayout_GetOffset(
         SlangReflectionVariableLayout* var,
         SlangParameterCategory category);
+
+    /** Get the register space/set of a variable in the specified parameter category.
+     *
+     * Returns `SLANG_UNKNOWN_SIZE` when the space depends on unresolved generic parameters or
+     * link-time constants.
+     */
     SLANG_API size_t spReflectionVariableLayout_GetSpace(
         SlangReflectionVariableLayout* var,
         SlangParameterCategory category);
@@ -816,7 +871,18 @@ extern "C"
 
     // Shader Parameter Reflection
 
+    /** Get the binding index for a shader parameter.
+     *
+     * Returns `SLANG_UNKNOWN_SIZE` when the index depends on unresolved generic parameters or
+     * link-time constants.
+     */
     SLANG_API unsigned spReflectionParameter_GetBindingIndex(SlangReflectionParameter* parameter);
+
+    /** Get the binding space for a shader parameter.
+     *
+     * Returns `SLANG_UNKNOWN_SIZE` when the space depends on unresolved generic parameters or
+     * link-time constants.
+     */
     SLANG_API unsigned spReflectionParameter_GetBindingSpace(SlangReflectionParameter* parameter);
 
     SLANG_API SlangResult spIsParameterLocationUsed(
@@ -930,7 +996,19 @@ extern "C"
         SlangReflection* reflection,
         char const* name);
 
+    /** Get the binding index for the global constant buffer.
+     *
+     * Returns `SLANG_UNKNOWN_SIZE` when the binding depends on unresolved generic parameters or
+     * link-time constants.
+     */
     SLANG_API SlangUInt spReflection_getGlobalConstantBufferBinding(SlangReflection* reflection);
+
+    /** Get the size of the global constant buffer.
+     *
+     * Returns `SLANG_UNBOUNDED_SIZE` for unbounded resources.
+     * Returns `SLANG_UNKNOWN_SIZE` when the size depends on unresolved generic parameters or
+     * link-time constants.
+     */
     SLANG_API size_t spReflection_getGlobalConstantBufferSize(SlangReflection* reflection);
 
     SLANG_API SlangReflectionType* spReflection_specializeType(
@@ -978,6 +1056,11 @@ extern "C"
     SLANG_API char const* spGetTranslationUnitSource(
         SlangCompileRequest* request,
         int translationUnitIndex);
+
+    /** Get the descriptor set/space index allocated for the bindless resource heap.
+     *  Returns -1 if the program does not use bindless resource heap.
+     */
+    SLANG_API SlangInt spReflection_getBindlessSpaceIndex(SlangReflection* reflection);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- Update `slang-deprecated.h` to match Slang v2026.4.2
- This header was missing from the previous update (#10), causing build errors (`spReflectionVariable_GetDefaultValueFloat` and `spReflection_getBindlessSpaceIndex` undeclared)
- `swift build` passes

## Test plan
- [x] `swift build` succeeds