### PR TITLE
Add CI test workflow for pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,32 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: macos-15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
       - name: Show Xcode version
         run: xcodebuild -version
+
+      - name: Cache Swift packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
       - name: Run tests
         run: |


### PR DESCRIPTION
## Summary
- Add `.github/workflows/test.yml` that runs `xcodebuild test` on PRs to main
- Uses `macos-15` runner with iOS Simulator (iPhone 16)
- Runs the `SwiftSlang-Package` scheme

Closes #14

## Test plan
- [ ] Verify this PR itself triggers the workflow
- [ ] Confirm tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)